### PR TITLE
updated ixbrl viewer ver

### DIFF
--- a/app/utils/xbrl_processing.py
+++ b/app/utils/xbrl_processing.py
@@ -57,7 +57,7 @@ def create_viewer_html(output_file : str,
 
     # command to run Arelle process
     plugins = os.path.join(ROOT, "dependencies", "ixbrl-viewer", "iXBRLViewerPlugin")
-    viewer_url = "https://cdn.jsdelivr.net/npm/ixbrl-viewer@1.4.8/iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js"
+    viewer_url = "https://cdn.jsdelivr.net/npm/ixbrl-viewer@1.4.36/iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js"
 
     print('viewer path', viewer_filepath)
     args = f"--plugins={plugins} -f {output_file} --save-viewer {viewer_filepath} --viewer-url {viewer_url}"


### PR DESCRIPTION
- changed to 1.4.36 latest, since on heroku, conversion fails 
error was:
`us=304 bytes=272 protocol=https
2024-10-07T23:08:40.689735+00:00 app[web.1]: 10.1.59.237 - - [07/Oct/2024 23:08:40] "POST /upload HTTP/1.1" 200 -
2024-10-07T23:08:43.687836+00:00 app[web.1]: viewer path /app/app/static/sessions_data/0239f638-06f9-41ff-84bd-62043ad44c9d/output/viewer.html
2024-10-07T23:08:43.688104+00:00 app[web.1]: Validating XBRL...
2024-10-07T23:08:43.733367+00:00 app[web.1]: Usage: main.py [options]
2024-10-07T23:08:43.733368+00:00 app[web.1]: 
2024-10-07T23:08:43.733374+00:00 app[web.1]: main.py: error: no such option: --save-viewer
2024-10-07T23:08:43.744046+00:00 heroku[router]: sock=backend at=error code=H18 desc="Server Request Interrupted" method=POST path="/upload" host=xbrl-converter-22f50351e04c.herokuapp.com request_id=ff929137-4ff6-4482-83cf-27457a85f2bc fwd="70.19.87.169" dyno=web.1 connect=0ms service=3056ms status=503 bytes= protocol=https
`