### PR TITLE
changed handling session using query param

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -110,6 +110,7 @@ def upload_file():
             print('viewer created\n')
 
             yield "data: Conversion finishing...\n\n"
+            yield f"data: redirect:/upload/complete?session_id={session_id}\n\n"
 
         except Exception as e:
             error_message = f"Error: {str(e)}"
@@ -120,20 +121,15 @@ def upload_file():
 
 @routes_bp.route('/upload/complete', methods=['GET'])
 def successful_upload():
-    # Check if session has expired
-    if check_session_expiry(session):
-        print("Session has expired")
-        return redirect(url_for('routes_bp.home'))
-
-    # Get the current session ID
-    session_id = session.get('session_id')
+    print("Entering successful_upload function")
+    # Get the session ID from query parameter
+    session_id = request.args.get('session_id') or session.get('session_id')
+    
     print('in successful upload func, id is: ', session_id)
     
     if not session_id:
         print("No session ID found")
         return redirect(url_for('routes_bp.home'))
-
-    update_session_timestamp(session)
 
     try:
         # make sure output.html can generate images
@@ -142,7 +138,7 @@ def successful_upload():
         generate_zip_file(session_id)
 
         print('before download url set')
-        download_url = url_for('static', filename=f'sessions_data/{session_id}/output/converted_xbrl.zip')
+        download_url = url_for('static', filename=f'sessions_data/{session_id}/output/converted_xbrl.zip', _external=True)
         print('download url is', download_url)
 
         return render_template("site/upload.html", session_id=session_id, download_url=download_url)


### PR DESCRIPTION
Reason: Worked on Heroku app but failed to get to /upload/complete on CLOSUP website due to some session issues:
`'Instead of relying solely on the Flask session, we can pass the session ID as a query parameter.'`

**Error log:**
```
2024-10-08T04:19:51.176802+00:00 app[web.1]: 
2024-10-08T04:19:52.356197+00:00 heroku[router]: at=info method=GET path="/static/js/spinner.js" host=xbrl-converter-22f50351e04c.herokuapp.com request_id=6745a6f3-9e1b-4149-b2b6-0b166d081979 fwd="67.245.5.249" dyno=web.1 connect=0ms service=1ms status=304 bytes=273 protocol=https
2024-10-08T04:19:52.232239+00:00 heroku[router]: at=info method=GET path="/upload/complete" host=xbrl-converter-22f50351e04c.herokuapp.com request_id=3bdc7698-0838-4436-b81a-ac15f8303f65 fwd="67.245.5.249" dyno=web.1 connect=1ms service=1ms status=302 bytes=393 protocol=https
2024-10-08T04:19:52.352278+00:00 heroku[router]: at=info method=GET path="/static/css/style.css" host=xbrl-converter-22f50351e04c.herokuapp.com request_id=000d905b-7493-4d3e-afaa-8390aa19e168 fwd="67.245.5.249" dyno=web.1 connect=1ms service=2ms status=304 bytes=272 protocol=https
2024-10-08T04:19:52.231085+00:00 app[web.1]: in successful upload func, id is:  None
2024-10-08T04:19:52.231100+00:00 app[web.1]: No session ID found
2024-10-08T04:19:52.231363+00:00 app[web.1]: 10.1.90.173 - - [08/Oct/2024 04:19:52] "GET /upload/complete HTTP/1.1" 302 -
```

`'in successful upload func, id is:  None'` indicates that when the /upload/complete route is accessed, there's no session ID available.

**Key changes:**
1. In the upload_file function, add a special event to redirect with the session ID:
` yield f"data: redirect:/upload/complete?session_id={session_id}\n\n"`
2. In the successful_upload function, we try to get the session ID from both the query parameter and the session:
'session_id = request.args.get('session_id') or session.get('session_id')'

On the client-side (JavaScript), we need to handle this redirect event. Add this to event source listener:
```
if (event.data.startsWith('redirect:')) {
    window.location.href = event.data.split(':')[1];
}
```

The session ID is passed explicitly in the URL, which should work regardless of how the app is hosted or embedded.