### PR TITLE
Member should be an element, not text

### DIFF
--- a/app/templates/xbrl/contexts.html
+++ b/app/templates/xbrl/contexts.html
@@ -5,7 +5,7 @@
         <xbrli:segment>
             {% for dim in context.dims() %}
             <xbrldi:{{dim.member_type}}Member dimension="{{dim.axis}}">
-                {{ dim.member_name }}
+                <{{ dim.member_name }}>
             </xbrldi:{{dim.member_type}}Member>
             {% endfor %}
         </xbrli:segment>   


### PR DESCRIPTION
Fix Arelle error 
```
[xmlSchema:valueError] Element xbrldi:typedMember type noContent value error: acfr:TotalsMember, value content not permitted - output 7.html 867
```

Related to #165