### PR TITLE
Fix server-side bug

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn main:app
+web: gunicorn main:app --workers=1

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn main:app --workers=1
+web: gunicorn main:app

--- a/app/routes.py
+++ b/app/routes.py
@@ -57,8 +57,10 @@ def upload_file():
             format = "gray"
 
             file_list, error = get_file_list(request, 'files[]')
+            print("Checked get_file_list:", error)
             if error:
                 yield f"data: Error: {error}\n\n"
+                print("Yielded error from get_file_list")
                 return
 
             yield "data: Uploading files\n\n"

--- a/app/routes.py
+++ b/app/routes.py
@@ -41,18 +41,17 @@ def view():
 
 @routes_bp.route('/upload', methods=['POST'])
 def upload_file():
-    session_id = str(uuid.uuid4())
-    session['session_id'] = session_id
-    update_session_timestamp(session)
-
-    # This gets the *directory* containing the current file (not where your shell is, but where THIS .py file is).
     PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
     base_path = os.path.join(PROJECT_ROOT, 'static', 'sessions_data')
 
     def generate():
+        # MOVE all former top-level logic INTO this generator!
+        session_id = str(uuid.uuid4())
+        session['session_id'] = session_id
+        update_session_timestamp(session)
         try:
             yield "data: Initializing upload\n\n"
-            print("Yielded - Initializing upload")  # <----- WATCH LOGS
+            print("Yielded - Initializing upload")
 
             input_folder, output_folder = create_session_folders(base_path, session_id)
             output_file = os.path.join(output_folder, "output.html")
@@ -60,7 +59,7 @@ def upload_file():
             print(f"Made folders: {input_folder}, {output_folder}")
 
             file_list, error = get_file_list(request, 'files[]')
-            print(f"file_list: {file_list}, error: {error}")  # <------ WATCH LOGS
+            print(f"file_list: {file_list}, error: {error}")
             if error:
                 print(f"Error at get_file_list: {error}")
                 yield f"data: Error: {error}\n\n"

--- a/app/routes.py
+++ b/app/routes.py
@@ -44,7 +44,7 @@ def upload_file():
     session_id = str(uuid.uuid4())
     session['session_id'] = session_id
     update_session_timestamp(session)
-    base_path = 'app/static/sessions_data/'
+    base_path = './app/static/sessions_data/'
 
     def generate():
         try:

--- a/app/routes.py
+++ b/app/routes.py
@@ -45,7 +45,8 @@ def upload_file():
     base_path = os.path.join(PROJECT_ROOT, 'static', 'sessions_data')
 
     def generate():
-        # debug statement
+        # DO NOT DELTE this print statement; referencing request.files is essential to 
+        # not return an empty stream on the Heroku deployment (will work locally even without)
         print("DEBUG ALL FILES:", dict(request.files))
 
         session_id = str(uuid.uuid4())

--- a/app/routes.py
+++ b/app/routes.py
@@ -150,3 +150,10 @@ def serve_image(session_id, filename):
 @routes_bp.route('/license')
 def license():
     return render_template('site/license.html', loading=True)
+
+@routes_bp.route("/debug-upload", methods=["POST"])
+def debug_upload():
+    print(dict(request.files))
+    print("files[] in request.files:", 'files[]' in request.files)
+    print("request.files.getlist('files[]'):", request.files.getlist('files[]'))
+    return "ok"

--- a/app/routes.py
+++ b/app/routes.py
@@ -45,8 +45,6 @@ def upload_file():
     base_path = os.path.join(PROJECT_ROOT, 'static', 'sessions_data')
 
     def generate():
-        # debug statement
-        print("DEBUG ALL FILES:", dict(request.files))
 
         session_id = str(uuid.uuid4())
         session['session_id'] = session_id
@@ -58,7 +56,6 @@ def upload_file():
             input_folder, output_folder = create_session_folders(base_path, session_id)
             output_file = os.path.join(output_folder, "output.html")
             format = "gray"
-            print(f"Made folders: {input_folder}, {output_folder}")
 
             file_list, error = get_file_list(request, 'files[]')
             print(f"file_list: {file_list}, error: {error}")
@@ -95,7 +92,6 @@ def upload_file():
                 return
 
             yield "data: Conversion finishing...\n\n"
-            yield f"data: complete:{session_id}\n\n"
 
         except Exception as e:
             yield f"data: Error: {str(e)}\n\n"

--- a/app/routes.py
+++ b/app/routes.py
@@ -45,7 +45,9 @@ def upload_file():
     base_path = os.path.join(PROJECT_ROOT, 'static', 'sessions_data')
 
     def generate():
-        # MOVE all former top-level logic INTO this generator!
+        # debug statement
+        print("DEBUG ALL FILES:", dict(request.files))
+
         session_id = str(uuid.uuid4())
         session['session_id'] = session_id
         update_session_timestamp(session)

--- a/app/routes.py
+++ b/app/routes.py
@@ -52,15 +52,18 @@ def upload_file():
     def generate():
         try:
             yield "data: Initializing upload\n\n"
+            print("Yielded - Initializing upload")  # <----- WATCH LOGS
+
             input_folder, output_folder = create_session_folders(base_path, session_id)
             output_file = os.path.join(output_folder, "output.html")
             format = "gray"
+            print(f"Made folders: {input_folder}, {output_folder}")
 
             file_list, error = get_file_list(request, 'files[]')
-            print("Checked get_file_list:", error)
+            print(f"file_list: {file_list}, error: {error}")  # <------ WATCH LOGS
             if error:
+                print(f"Error at get_file_list: {error}")
                 yield f"data: Error: {error}\n\n"
-                print("Yielded error from get_file_list")
                 return
 
             yield "data: Uploading files\n\n"

--- a/app/routes.py
+++ b/app/routes.py
@@ -44,7 +44,10 @@ def upload_file():
     session_id = str(uuid.uuid4())
     session['session_id'] = session_id
     update_session_timestamp(session)
-    base_path = './app/static/sessions_data/'
+
+    # This gets the *directory* containing the current file (not where your shell is, but where THIS .py file is).
+    PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+    base_path = os.path.join(PROJECT_ROOT, 'static', 'sessions_data')
 
     def generate():
         try:

--- a/app/routes.py
+++ b/app/routes.py
@@ -45,6 +45,8 @@ def upload_file():
     base_path = os.path.join(PROJECT_ROOT, 'static', 'sessions_data')
 
     def generate():
+        # debug statement
+        print("DEBUG ALL FILES:", dict(request.files))
 
         session_id = str(uuid.uuid4())
         session['session_id'] = session_id
@@ -56,6 +58,7 @@ def upload_file():
             input_folder, output_folder = create_session_folders(base_path, session_id)
             output_file = os.path.join(output_folder, "output.html")
             format = "gray"
+            print(f"Made folders: {input_folder}, {output_folder}")
 
             file_list, error = get_file_list(request, 'files[]')
             print(f"file_list: {file_list}, error: {error}")
@@ -92,6 +95,7 @@ def upload_file():
                 return
 
             yield "data: Conversion finishing...\n\n"
+            yield f"data: complete:{session_id}\n\n"
 
         except Exception as e:
             yield f"data: Error: {str(e)}\n\n"

--- a/app/routes.py
+++ b/app/routes.py
@@ -150,10 +150,3 @@ def serve_image(session_id, filename):
 @routes_bp.route('/license')
 def license():
     return render_template('site/license.html', loading=True)
-
-# @routes_bp.route("/debug-upload", methods=["POST"])
-# def debug_upload():
-#     print(dict(request.files))
-#     print("files[] in request.files:", 'files[]' in request.files)
-#     print("request.files.getlist('files[]'):", request.files.getlist('files[]'))
-#     return "ok"

--- a/app/routes.py
+++ b/app/routes.py
@@ -27,7 +27,7 @@ def home():
 
 @routes_bp.route('/viewer')
 def view():
-    session_id = session.get('session_id')
+    session_id = request.args.get('session_id') or session.get('session_id')    
     if not session_id:
         return "Session not found", 404
 
@@ -104,7 +104,6 @@ def upload_file():
 
 @routes_bp.route('/upload/complete', methods=['GET'])
 def successful_upload():
-    print("Entering successful_upload function")
     session_id = request.args.get('session_id') or session.get('session_id')
     
     if not session_id:
@@ -152,9 +151,9 @@ def serve_image(session_id, filename):
 def license():
     return render_template('site/license.html', loading=True)
 
-@routes_bp.route("/debug-upload", methods=["POST"])
-def debug_upload():
-    print(dict(request.files))
-    print("files[] in request.files:", 'files[]' in request.files)
-    print("request.files.getlist('files[]'):", request.files.getlist('files[]'))
-    return "ok"
+# @routes_bp.route("/debug-upload", methods=["POST"])
+# def debug_upload():
+#     print(dict(request.files))
+#     print("files[] in request.files:", 'files[]' in request.files)
+#     print("request.files.getlist('files[]'):", request.files.getlist('files[]'))
+#     return "ok"

--- a/app/static/js/spinner.js
+++ b/app/static/js/spinner.js
@@ -198,12 +198,6 @@ function startProcessing(event) {
         message: 'Starting process...'
     });
 
-    // Debugging
-    console.log("FormData keys:");
-    for (let p of formData.entries()) {
-        console.log(p[0], p[1]);
-    }
-
     // Send POST request to initiate the upload
     fetch('/upload', {
         method: 'POST',

--- a/app/static/js/spinner.js
+++ b/app/static/js/spinner.js
@@ -205,7 +205,8 @@ function startProcessing(event) {
     }
 
     // Send POST request to initiate the upload
-    fetch('/upload', {
+    // change back
+    fetch('/debug-upload', {
         method: 'POST',
         body: formData,
         headers: {

--- a/app/static/js/spinner.js
+++ b/app/static/js/spinner.js
@@ -205,8 +205,7 @@ function startProcessing(event) {
     }
 
     // Send POST request to initiate the upload
-    // change back
-    fetch('/debug-upload', {
+    fetch('/upload', {
         method: 'POST',
         body: formData,
         headers: {

--- a/app/static/js/spinner.js
+++ b/app/static/js/spinner.js
@@ -218,18 +218,15 @@ function startProcessing(event) {
 
         function readStream() {
             reader.read().then(({ done, value }) => {
-                console.log('Read chunk:', done, value);
                 if (done) {
                     console.log('Stream complete');
                     return;
                 }
 
                 const chunk = decoder.decode(value, { stream: true });
-                console.log('Decoded chunk:', chunk);
 
                 const lines = chunk.split('\n');
                 lines.forEach(line => {
-                    console.log('Received line:', line); // Log each line for visibility
 
                     if (line.startsWith('data:')) {
                         const message = line.slice(5).trim();

--- a/app/static/js/spinner.js
+++ b/app/static/js/spinner.js
@@ -204,9 +204,6 @@ function startProcessing(event) {
         body: formData
     }).then(response => {
 
-        // set newWindow to null
-        let newWindow = null;
-
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
 

--- a/app/static/js/spinner.js
+++ b/app/static/js/spinner.js
@@ -198,10 +198,19 @@ function startProcessing(event) {
         message: 'Starting process...'
     });
 
+    // Debugging
+    console.log("FormData keys:");
+    for (let p of formData.entries()) {
+        console.log(p[0], p[1]);
+    }
+
     // Send POST request to initiate the upload
     fetch('/upload', {
         method: 'POST',
-        body: formData
+        body: formData,
+        headers: {
+            'Accept-Encoding': 'identity'
+        }
     }).then(response => {
 
         const reader = response.body.getReader();

--- a/app/templates/site/upload.html
+++ b/app/templates/site/upload.html
@@ -21,7 +21,7 @@
 {% block card2 %}
     <div class="card-header">View your machine-readable financial statement in browser</div>
     <div class="card-body text-center">
-        <a href="/viewer" target="_blank">
+        <a href="{{ url_for('routes_bp.view') }}?session_id={{ session_id }}" target="_blank">
             <button type="button" class="btn btn-michigan btn-lg">Click to view in browser</button>
         </a>
     </div>

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -3,3 +3,4 @@
 from .constants import *
 from .helper_functions import *
 from .xbrl_processing import *
+from .generate import *

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -3,4 +3,4 @@
 from .constants import *
 from .helper_functions import *
 from .xbrl_processing import *
-from .generate import *
+from .upload_helpers import *

--- a/app/utils/generate.py
+++ b/app/utils/generate.py
@@ -1,0 +1,77 @@
+import os
+from flask import request, Response, stream_with_context
+from .constants import *
+from .helper_functions import *
+from .xbrl_processing import *
+
+def create_folders(session_id):
+    input_folder = os.path.join('app/static/sessions_data/', session_id, 'input')
+    output_folder = os.path.join('app/static/sessions_data/', session_id, 'output')
+
+    # Create session folders if they don't exist
+    os.makedirs(input_folder, exist_ok=True)
+    os.makedirs(output_folder, exist_ok=True)
+
+    output_file = os.path.join(output_folder, "output.html")
+
+    return input_folder, output_file
+
+def download_files(input_folder):
+        # Check for the 'files[]' part in the request
+        if 'files[]' not in request.files:
+            yield "data: Error: No files submitted\n\n"
+            return
+
+        # Retrieve the list of files from the request
+        file_list = request.files.getlist('files[]')
+
+        for file in file_list:
+            if file.filename == '':
+                yield "data: Error: No selected file\n\n"
+                return
+            if not allowed_file(file.filename):
+                yield f"data: Error: Disallowed file extension. Allowed: {', '.join(ALLOWED_EXTENSIONS)}\n\n"
+                return
+            
+            # Save uploaded files to session input folder
+            if file and allowed_file(file.filename):
+                file.save(os.path.join(input_folder, file.filename))
+
+        yield "data: Processing and validating files\n\n"
+        return file_list
+
+def check_for_excel(file_list):
+    excel_files = [file for file in file_list if is_spreadsheet(file.filename)]
+
+    if len(excel_files) == 0:
+        yield "data: Error: An Excel file is missing\n\n"
+        return
+    elif len(excel_files) != 1:
+        yield "data: Error: Please upload exactly one Excel file\n\n"
+        return
+
+def generate(session_id):
+    
+    yield "data: Initializing upload\n\n"
+    # create folders
+    input_folder, output_file = create_folders(session_id)
+    # process uploaded files
+    file_list = download_files(input_folder)
+    # check for an excel file
+    check_for_excel(file_list)
+    # create XBRL file
+    yield "data: Creating iXBRL file\n\n"
+    write_html(file_list, output_file, format)
+    yield "data: Creating viewer\n\n"
+    viewer_output_path = f'app/static/sessions_data/{session_id}/output/'
+        
+    try:
+        create_viewer_html(output_file, viewer_output_path)
+    except Exception as e:
+        yield f"data: Error creating viewer: {str(e)}\n\n"
+        return
+        
+    yield "data: Conversion finishing...\n\n"
+    yield f"data: complete:{session_id}\n\n"  # Make sure this line is present
+
+    return Response(stream_with_context(generate()), content_type='text/event-stream')

--- a/app/utils/generate.py
+++ b/app/utils/generate.py
@@ -1,77 +1,135 @@
-import os
-from flask import request, Response, stream_with_context
-from .constants import *
-from .helper_functions import *
-from .xbrl_processing import *
+# import os
+# from flask import request, Response, stream_with_context
+# from .constants import *
+# from .helper_functions import *
+# from .xbrl_processing import *
 
-def create_folders(session_id):
-    input_folder = os.path.join('app/static/sessions_data/', session_id, 'input')
-    output_folder = os.path.join('app/static/sessions_data/', session_id, 'output')
+# def create_folders(session_id):
+#     input_folder = os.path.join('app/static/sessions_data/', session_id, 'input')
+#     output_folder = os.path.join('app/static/sessions_data/', session_id, 'output')
 
-    # Create session folders if they don't exist
-    os.makedirs(input_folder, exist_ok=True)
-    os.makedirs(output_folder, exist_ok=True)
+#     # Create session folders if they don't exist
+#     os.makedirs(input_folder, exist_ok=True)
+#     os.makedirs(output_folder, exist_ok=True)
 
-    output_file = os.path.join(output_folder, "output.html")
+#     output_file = os.path.join(output_folder, "output.html")
 
-    return input_folder, output_file
+#     return input_folder, output_file
 
-def download_files(input_folder):
-        # Check for the 'files[]' part in the request
-        if 'files[]' not in request.files:
-            yield "data: Error: No files submitted\n\n"
-            return
+# import os
+# from flask import request, Response, stream_with_context
+# from .constants import *
+# from .helper_functions import *
+# from .xbrl_processing import *
 
-        # Retrieve the list of files from the request
-        file_list = request.files.getlist('files[]')
+# def create_folders(session_id):
+#     input_folder = os.path.join('app/static/sessions_data/', session_id, 'input')
+#     output_folder = os.path.join('app/static/sessions_data/', session_id, 'output')
 
-        for file in file_list:
-            if file.filename == '':
-                yield "data: Error: No selected file\n\n"
-                return
-            if not allowed_file(file.filename):
-                yield f"data: Error: Disallowed file extension. Allowed: {', '.join(ALLOWED_EXTENSIONS)}\n\n"
-                return
+#     # Create session folders if they don't exist
+#     os.makedirs(input_folder, exist_ok=True)
+#     os.makedirs(output_folder, exist_ok=True)
+
+#     output_file = os.path.join(output_folder, "output.html")
+
+#     return input_folder, output_file
+
+# def download_files(input_folder, files):
+#         # Check for the 'files[]' part in the request
+#         if 'files[]' not in files:
+#             yield "data: Error: No files submitted\n\n"
+#             return
+
+#         # Retrieve the list of files from the request
+#         file_list = files.getlist('files[]')
+
+#         for file in file_list:
+#             if file.filename == '':
+#                 yield "data: Error: No selected file\n\n"
+#                 return
+#             if not allowed_file(file.filename):
+#                 yield f"data: Error: Disallowed file extension. Allowed: {', '.join(ALLOWED_EXTENSIONS)}\n\n"
+#                 return
             
-            # Save uploaded files to session input folder
-            if file and allowed_file(file.filename):
-                file.save(os.path.join(input_folder, file.filename))
+#             # Save uploaded files to session input folder
+#             if file and allowed_file(file.filename):
+#                 file.save(os.path.join(input_folder, file.filename))
 
-        yield "data: Processing and validating files\n\n"
-        return file_list
+#         yield "data: Processing and validating files\n\n"
+#         return file_list
 
-def check_for_excel(file_list):
-    excel_files = [file for file in file_list if is_spreadsheet(file.filename)]
+# def check_for_excel(file_list):
+#     excel_files = [file for file in file_list if is_spreadsheet(file.filename)]
 
-    if len(excel_files) == 0:
-        yield "data: Error: An Excel file is missing\n\n"
-        return
-    elif len(excel_files) != 1:
-        yield "data: Error: Please upload exactly one Excel file\n\n"
-        return
+#     if len(excel_files) == 0:
+#         yield "data: Error: An Excel file is missing\n\n"
+#         return
+#     elif len(excel_files) != 1:
+#         yield "data: Error: Please upload exactly one Excel file\n\n"
+#         return
 
-def generate(session_id):
+# def generate(session_id, files):
+#     yield "data: Initializing upload\n\n"
+#     input_folder, output_file = create_folders(session_id)
+
+#     ok, file_list_or_error = download_files(input_folder, files)
+#     if not ok:
+#         yield f"data: {file_list_or_error}\n\n"
+#         return
+
+#     file_list = file_list_or_error
+
+#     ok, error = check_for_excel(file_list)
+#     if not ok:
+#         yield f"data: {error}\n\n"
+#         return
+
+#     yield "data: Creating iXBRL file\n\n"
+#     write_html(file_list, output_file, format)
+#     yield "data: Creating viewer\n\n"
+#     viewer_output_path = f'app/static/sessions_data/{session_id}/output/'
+
+#     try:
+#         create_viewer_html(output_file, viewer_output_path)
+#     except Exception as e:
+#         yield f"data: Error creating viewer: {str(e)}\n\n"
+#         return
+
+#     yield "data: Conversion finishing...\n\n"
+#     yield f"data: complete:{session_id}\n\n"
+
+# def check_for_excel(file_list):
+#     excel_files = [file for file in file_list if is_spreadsheet(file.filename)]
+
+#     if len(excel_files) == 0:
+#         yield "data: Error: An Excel file is missing\n\n"
+#         return
+#     elif len(excel_files) != 1:
+#         yield "data: Error: Please upload exactly one Excel file\n\n"
+#         return
+
+# def generate(session_id, files):
     
-    yield "data: Initializing upload\n\n"
-    # create folders
-    input_folder, output_file = create_folders(session_id)
-    # process uploaded files
-    file_list = download_files(input_folder)
-    # check for an excel file
-    check_for_excel(file_list)
-    # create XBRL file
-    yield "data: Creating iXBRL file\n\n"
-    write_html(file_list, output_file, format)
-    yield "data: Creating viewer\n\n"
-    viewer_output_path = f'app/static/sessions_data/{session_id}/output/'
+#     yield "data: Initializing upload\n\n"
+#     # create folders
+#     input_folder, output_file = create_folders(session_id)
+#     # process uploaded files
+#     file_list = download_files(input_folder, files)
+#     # check for an excel file
+#     check_for_excel(file_list)
+#     # create XBRL file
+#     yield "data: Creating iXBRL file\n\n"
+#     write_html(file_list, output_file, format)
+#     yield "data: Creating viewer\n\n"
+#     viewer_output_path = f'app/static/sessions_data/{session_id}/output/'
         
-    try:
-        create_viewer_html(output_file, viewer_output_path)
-    except Exception as e:
-        yield f"data: Error creating viewer: {str(e)}\n\n"
-        return
+#     try:
+#         create_viewer_html(output_file, viewer_output_path)
+#     except Exception as e:
+#         yield f"data: Error creating viewer: {str(e)}\n\n"
+#         return
         
-    yield "data: Conversion finishing...\n\n"
-    yield f"data: complete:{session_id}\n\n"  # Make sure this line is present
+#     yield "data: Conversion finishing...\n\n"
+#     yield f"data: complete:{session_id}\n\n"  # Make sure this line is present
 
-    return Response(stream_with_context(generate()), content_type='text/event-stream')
+#     return Response(stream_with_context(generate()), content_type='text/event-stream')

--- a/app/utils/upload_helpers.py
+++ b/app/utils/upload_helpers.py
@@ -1,0 +1,40 @@
+import os
+from .constants import *
+from .helper_functions import *
+from .xbrl_processing import *
+
+def create_session_folders(base_path, session_id):
+    input_folder = os.path.join(base_path, session_id, 'input')
+    output_folder = os.path.join(base_path, session_id, 'output')
+    os.makedirs(input_folder, exist_ok=True)
+    os.makedirs(output_folder, exist_ok=True)
+    return input_folder, output_folder
+
+def get_file_list(request, field_name='files[]'):
+    """Return file list or error message if not present."""
+    if field_name not in request.files:
+        return None, "No files submitted"
+    file_list = request.files.getlist(field_name)
+    if not file_list or all(f.filename == '' for f in file_list):
+        return None, "No selected file"
+    return file_list, None
+
+def validate_and_save_files(file_list, allowed_exts, input_folder):
+    """Check file types and save, return (saved_file_list, error)"""
+    saved_files = []
+    for file in file_list:
+        if not allowed_file(file.filename):
+            allowed_str = ', '.join(allowed_exts)
+            return None, f"Disallowed file extension. Allowed: {allowed_str}"
+        save_path = os.path.join(input_folder, file.filename)
+        file.save(save_path)
+        saved_files.append(file)
+    return saved_files, None
+
+def find_excel_files(file_list, is_excel_fn):
+    excels = [f for f in file_list if is_excel_fn(f.filename)]
+    if len(excels) == 0:
+        return None, "An Excel file is missing"
+    elif len(excels) != 1:
+        return None, "Please upload exactly one Excel file"
+    return excels, None

--- a/app/utils/xbrl_processing.py
+++ b/app/utils/xbrl_processing.py
@@ -53,11 +53,15 @@ def create_viewer_html(output_file : str,
     Runs Arelle and ixbrl-viewer submodules to create a viewer html and 
     accompanying javascript file.
     """
+
+    # Check that file exists
+    if not os.path.exists(output_file):
+        raise FileNotFoundError(f"Output file does not exist: {output_file}")
+
+    output_file = os.path.abspath(output_file)
     viewer_filepath = os.path.join(ROOT, viewer_outpath, 'viewer.html')
 
     # command to run Arelle process
-    # OLD YOU DON'T NEED THIS!! plugins = os.path.join(ROOT, "dependencies", "ixbrl-viewer", "iXBRLViewerPlugin")
-    # ixbrl-viewer automatically uses "iXBRLViewerPlugin:load_plugin_url"
     viewer_url = "https://cdn.jsdelivr.net/npm/ixbrl-viewer@1.4.48/iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js"
     args = f"--plugins=ixbrl-viewer -f {output_file} --save-viewer {viewer_filepath} --viewer-url {viewer_url}"
     
@@ -71,7 +75,6 @@ def create_viewer_html(output_file : str,
     except Exception as e:
         print(f"Error during XBRL validation: {str(e)}")
         raise
-
     
     # Read in the generated HTML
     print("Creating interactive viewer...")

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 """
 Initialize the Flask application and run the server.
 
-Last updated: K. Wheelan, April 2024
+Last updated: K. Wheelan, July 2025
 """
 
 from app import app

--- a/main.py
+++ b/main.py
@@ -7,6 +7,10 @@ Last updated: K. Wheelan, July 2025
 from app import app
 import os
 import warnings
+import sys
+
+# make sure gunicorn prints debug statements
+print("debug", file=sys.stderr)
 
 warnings.filterwarnings("ignore", category=UserWarning, module="openpyxl")
 # Disable all FutureWarnings


### PR DESCRIPTION
## Overview

Fixes file upload issue. Previously, the app was stalling after file upload on Heroku deployment (but not when run locally).

Bizarrely the key 1) moving the session ID generation into the generator function for the content streaming, and 2) adding the debug print statement as the first line of the generator to access request.files.

## Other changes

- explicitly invokes gunicorn
- defines Python version; updates requirements.txt
- splits generate function in upload route into helper functions, now in utils/
- allows print statement logging in Heroku logs
- updates session-id to be created in the generator for the content streaming
- Adds session ID to viewer url

## Issues addressed

- Close issue #211 